### PR TITLE
Fixed bug with focus after element

### DIFF
--- a/code/src/frontend/styles/components/image-lightbox.scss
+++ b/code/src/frontend/styles/components/image-lightbox.scss
@@ -30,7 +30,7 @@
   &:focus {
     opacity: 0.7;
 
-    &::before {
+    &::after {
       transform-origin: center;
       transform: scale(1.2) rotate(135deg);
     }


### PR DESCRIPTION
As the "::before" element was changed to an "::after" element, it needed to be changed for focus as well.